### PR TITLE
Add seven-layer obfuscator with heuristic assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Seven-layer Obfuscator
+
+This repository contains a demonstrational seven-layer obfuscator backed by a
+heuristic AI-like assistant.  The assistant analyses input text and derives a
+configuration that controls each layer of the obfuscation pipeline.
+
+## Features
+
+- **Seven reversible layers** consisting of compression, XOR, Base64, padding,
+  permutation, bit rotation and ASCII armouring.
+- **Deterministic assistant** that inspects the message and proposes a plan
+  (encryption keys, permutation, compression level, etc.).
+- **Unicode aware** end-to-end workflow.
+
+## Usage
+
+```python
+from src import LayerAdvisor, SevenLayerObfuscator
+
+message = "Пример сообщения"
+plan = LayerAdvisor().suggest_plan(message)
+obfuscator = SevenLayerObfuscator(plan)
+obfuscated = obfuscator.obfuscate(message)
+original = obfuscator.deobfuscate(obfuscated)
+assert original == message
+```
+
+Running the test-suite requires `pytest`:
+
+```bash
+pip install pytest
+pytest
+```

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,10 @@
+"""Seven-layer obfuscator package."""
+
+from .assistant import LayerAdvisor, ObfuscationPlan
+from .obfuscator import SevenLayerObfuscator
+
+__all__ = [
+    "LayerAdvisor",
+    "ObfuscationPlan",
+    "SevenLayerObfuscator",
+]

--- a/src/assistant.py
+++ b/src/assistant.py
@@ -1,0 +1,170 @@
+"""Heuristic "AI" assistant for configuring the seven-layer obfuscator.
+
+The goal of the assistant is to analyse the user provided payload and derive
+configuration parameters that feed the obfuscation pipeline.  While this is not
+an actual machine learning model, the assistant mimics an intelligent helper by
+combining statistical analysis with deterministic pseudo-random number
+generation.  This keeps the suggestions reproducible while still reacting to the
+shape of the source text.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from statistics import mean
+from typing import List, Sequence
+
+
+@dataclass(frozen=True)
+class ObfuscationPlan:
+    """Container for the seven-layer obfuscator configuration.
+
+    Attributes
+    ----------
+    xor_key:
+        The byte-string used by the XOR layer.  The key length influences the
+        diffusion and the plan ensures a minimum length of 8 bytes.
+    block_size:
+        Block size for the permutation and padding layers.  The permutation is
+        defined over ``range(block_size)`` and both layers must agree on the same
+        value.
+    permutation:
+        Concrete permutation used by :class:`PermutationLayer`.  The list length
+        matches ``block_size`` and contains every integer in ``range(block_size)``
+        exactly once.
+    bit_rotation:
+        How many bits (1-7) each byte is rotated to the left within the bit
+        rotation layer.  The inverse operation rotates in the other direction.
+    compression_level:
+        Zlib compression level (0-9).  The assistant tweaks this depending on
+        the entropy of the source text.
+    base64_variant:
+        Either ``"standard"`` or ``"urlsafe"``.  ``urlsafe`` avoids ``+`` and
+        ``/`` which might be handy when embedding the payload in URLs.
+    armor:
+        Final ASCII armoring step.  ``"base32"`` is compact yet conservative for
+        short inputs, whereas ``"base85"`` is denser and preferred for longer
+        texts.
+    """
+
+    xor_key: bytes
+    block_size: int
+    permutation: Sequence[int]
+    bit_rotation: int
+    compression_level: int
+    base64_variant: str
+    armor: str
+
+    def describe(self) -> str:
+        """Return a human-readable description of the plan."""
+
+        permutation_preview = "-".join(str(i) for i in self.permutation[:6])
+        return (
+            "Obfuscation plan: "
+            f"xor_key={len(self.xor_key)} bytes, "
+            f"block_size={self.block_size}, "
+            f"perm~[{permutation_preview}...], "
+            f"bit_rotation={self.bit_rotation}, "
+            f"compression_level={self.compression_level}, "
+            f"base64_variant={self.base64_variant}, "
+            f"armor={self.armor}"
+        )
+
+
+class LayerAdvisor:
+    """Pseudo-AI assistant that crafts an :class:`ObfuscationPlan`.
+
+    The adviser uses deterministic randomness that depends on statistics of the
+    message.  That way repeated calls with the same message return the same
+    configuration, yet small changes in the input yield noticeably different
+    results.
+    """
+
+    def __init__(self, *, seed: int | None = None) -> None:
+        self._seed = seed
+
+    def suggest_plan(self, message: str) -> ObfuscationPlan:
+        """Analyse ``message`` and return a tailored obfuscation plan."""
+
+        if not message:
+            raise ValueError("message must not be empty")
+
+        # Basic features about the payload.
+        code_points = [ord(ch) for ch in message]
+        length = len(code_points)
+        ascii_share = sum(1 for cp in code_points if cp < 128) / length
+        diversity = len(set(code_points)) / length
+        avg_code_point = mean(code_points)
+
+        # Deterministic random seed derived from message statistics.
+        digest = sha256(message.encode("utf-8")).digest()
+        seed = int.from_bytes(digest[:8], "big")
+        if self._seed is not None:
+            seed ^= self._seed
+
+        rng = _DeterministicRandom(seed)
+
+        # XOR key length scales with message length and diversity.
+        base_key_len = max(8, min(48, int(length * (0.25 + diversity))))
+        xor_key = bytes(rng.randint(0, 255) for _ in range(base_key_len))
+
+        # Block size influences permutation and padding.
+        block_size_candidates = [6, 7, 8, 9, 10, 12]
+        block_size = block_size_candidates[int(avg_code_point) % len(block_size_candidates)]
+
+        permutation = list(range(block_size))
+        rng.shuffle(permutation)
+
+        # Bit rotation between 1 and 7.  Higher entropy texts rotate further.
+        rotation = max(1, min(7, int(1 + diversity * 7)))
+
+        # Compression level derived from ascii share and length.
+        if length < 32:
+            compression_level = 6
+        elif ascii_share < 0.6:
+            compression_level = 9
+        else:
+            compression_level = 4 + int((1 - diversity) * 3)
+        compression_level = max(1, min(9, compression_level))
+
+        base64_variant = "urlsafe" if ascii_share > 0.85 else "standard"
+        armor = "base85" if length > 48 else "base32"
+
+        return ObfuscationPlan(
+            xor_key=xor_key,
+            block_size=block_size,
+            permutation=tuple(permutation),
+            bit_rotation=rotation,
+            compression_level=compression_level,
+            base64_variant=base64_variant,
+            armor=armor,
+        )
+
+
+class _DeterministicRandom:
+    """Minimal random generator with shuffle support.
+
+    We keep the implementation small to avoid depending on :mod:`random` which
+    carries global state.  The generator implements only the functionality we
+    require (integers and shuffling).
+    """
+
+    def __init__(self, seed: int) -> None:
+        self.state = seed & ((1 << 64) - 1)
+        if self.state == 0:
+            self.state = 0xDEADBEEFCAFEBABE
+
+    def randint(self, a: int, b: int) -> int:
+        if a > b:
+            raise ValueError("a must be <= b")
+        span = b - a + 1
+        self.state = (1103515245 * self.state + 12345) & 0x7FFFFFFF
+        return a + self.state % span
+
+    def shuffle(self, items: List[int]) -> None:
+        for i in range(len(items) - 1, 0, -1):
+            j = self.randint(0, i)
+            items[i], items[j] = items[j], items[i]
+
+
+__all__ = ["LayerAdvisor", "ObfuscationPlan"]

--- a/src/obfuscator.py
+++ b/src/obfuscator.py
@@ -1,0 +1,209 @@
+"""Seven-layer obfuscation pipeline.
+
+The module provides :class:`SevenLayerObfuscator` which applies a stack of
+reversible transformations to a text message.  The transformations operate on
+bytes and are designed to be lossless so that a matching :meth:`deobfuscate`
+call is guaranteed to recover the original payload.
+"""
+from __future__ import annotations
+
+import base64
+import zlib
+from dataclasses import dataclass
+from typing import Sequence
+
+from .assistant import ObfuscationPlan
+
+
+class LayerProtocol:
+    """Simple forward/backward protocol implemented by all layers."""
+
+    def forward(self, data: bytes) -> bytes:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def backward(self, data: bytes) -> bytes:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+@dataclass
+class SevenLayerObfuscator:
+    """Concrete seven-layer obfuscator.
+
+    Parameters
+    ----------
+    plan:
+        Configuration produced by :class:`~payload.assistant.LayerAdvisor`.
+    """
+
+    plan: ObfuscationPlan
+
+    def __post_init__(self) -> None:
+        self._layers: Sequence[LayerProtocol] = (
+            _ZlibLayer(self.plan.compression_level),
+            _XorLayer(self.plan.xor_key),
+            _Base64Layer(self.plan.base64_variant),
+            _PaddingLayer(self.plan.block_size),
+            _PermutationLayer(self.plan.permutation),
+            _BitRotationLayer(self.plan.bit_rotation),
+            _AsciiArmorLayer(self.plan.armor),
+        )
+
+    def obfuscate(self, message: str) -> str:
+        """Return an obfuscated representation of ``message``."""
+
+        data = message.encode("utf-8")
+        for layer in self._layers:
+            data = layer.forward(data)
+        return data.decode("ascii")
+
+    def deobfuscate(self, payload: str) -> str:
+        """Recover the original message from ``payload``."""
+
+        data = payload.encode("ascii")
+        for layer in reversed(self._layers):
+            data = layer.backward(data)
+        return data.decode("utf-8")
+
+
+class _ZlibLayer(LayerProtocol):
+    def __init__(self, level: int) -> None:
+        self.level = max(0, min(9, level))
+
+    def forward(self, data: bytes) -> bytes:
+        return zlib.compress(data, self.level)
+
+    def backward(self, data: bytes) -> bytes:
+        return zlib.decompress(data)
+
+
+class _XorLayer(LayerProtocol):
+    def __init__(self, key: bytes) -> None:
+        if not key:
+            raise ValueError("key must not be empty")
+        self.key = key
+
+    def _apply(self, data: bytes) -> bytes:
+        key = self.key
+        key_len = len(key)
+        return bytes(b ^ key[i % key_len] for i, b in enumerate(data))
+
+    forward = _apply
+    backward = _apply
+
+
+class _Base64Layer(LayerProtocol):
+    def __init__(self, variant: str) -> None:
+        if variant not in {"standard", "urlsafe"}:
+            raise ValueError("variant must be 'standard' or 'urlsafe'")
+        self.variant = variant
+
+    def forward(self, data: bytes) -> bytes:
+        if self.variant == "urlsafe":
+            return base64.urlsafe_b64encode(data)
+        return base64.b64encode(data)
+
+    def backward(self, data: bytes) -> bytes:
+        if self.variant == "urlsafe":
+            return base64.urlsafe_b64decode(data)
+        return base64.b64decode(data)
+
+
+class _PaddingLayer(LayerProtocol):
+    def __init__(self, block_size: int) -> None:
+        if block_size <= 0:
+            raise ValueError("block_size must be positive")
+        self.block_size = block_size
+
+    def forward(self, data: bytes) -> bytes:
+        pad_len = self.block_size - (len(data) % self.block_size)
+        if pad_len == 0:
+            pad_len = self.block_size
+        return data + bytes([pad_len]) * pad_len
+
+    def backward(self, data: bytes) -> bytes:
+        if not data:
+            raise ValueError("cannot unpad empty data")
+        pad_len = data[-1]
+        if pad_len <= 0 or pad_len > self.block_size:
+            raise ValueError("invalid padding")
+        if data[-pad_len:] != bytes([pad_len]) * pad_len:
+            raise ValueError("invalid padding")
+        return data[:-pad_len]
+
+
+class _PermutationLayer(LayerProtocol):
+    def __init__(self, permutation: Sequence[int]) -> None:
+        if not permutation:
+            raise ValueError("permutation must not be empty")
+        if sorted(permutation) != list(range(len(permutation))):
+            raise ValueError("permutation must be a rearrangement of range(n)")
+        self.permutation = tuple(permutation)
+        inverse = [0] * len(permutation)
+        for index, dest in enumerate(permutation):
+            inverse[dest] = index
+        self.inverse = tuple(inverse)
+
+    def forward(self, data: bytes) -> bytes:
+        block_size = len(self.permutation)
+        if len(data) % block_size:
+            raise ValueError("data length must be multiple of block size")
+        return b"".join(
+            self._permute_block(data[i : i + block_size])
+            for i in range(0, len(data), block_size)
+        )
+
+    def backward(self, data: bytes) -> bytes:
+        block_size = len(self.inverse)
+        if len(data) % block_size:
+            raise ValueError("data length must be multiple of block size")
+        return b"".join(
+            self._invert_block(data[i : i + block_size])
+            for i in range(0, len(data), block_size)
+        )
+
+    def _permute_block(self, block: bytes) -> bytes:
+        permuted = bytearray(len(block))
+        for src_index, dest_index in enumerate(self.permutation):
+            permuted[dest_index] = block[src_index]
+        return bytes(permuted)
+
+    def _invert_block(self, block: bytes) -> bytes:
+        restored = bytearray(len(block))
+        for dest_index, src_index in enumerate(self.inverse):
+            restored[src_index] = block[dest_index]
+        return bytes(restored)
+
+
+class _BitRotationLayer(LayerProtocol):
+    def __init__(self, shift: int) -> None:
+        if not (1 <= shift <= 7):
+            raise ValueError("shift must be in range 1..7")
+        self.shift = shift
+
+    def forward(self, data: bytes) -> bytes:
+        shift = self.shift
+        return bytes(((b << shift) & 0xFF) | (b >> (8 - shift)) for b in data)
+
+    def backward(self, data: bytes) -> bytes:
+        shift = self.shift
+        return bytes((b >> shift) | ((b << (8 - shift)) & 0xFF) for b in data)
+
+
+class _AsciiArmorLayer(LayerProtocol):
+    def __init__(self, mode: str) -> None:
+        if mode not in {"base32", "base85"}:
+            raise ValueError("mode must be 'base32' or 'base85'")
+        self.mode = mode
+
+    def forward(self, data: bytes) -> bytes:
+        if self.mode == "base32":
+            return base64.b32encode(data)
+        return base64.b85encode(data)
+
+    def backward(self, data: bytes) -> bytes:
+        if self.mode == "base32":
+            return base64.b32decode(data)
+        return base64.b85decode(data)
+
+
+__all__ = ["SevenLayerObfuscator"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_obfuscator.py
+++ b/tests/test_obfuscator.py
@@ -1,0 +1,41 @@
+import pytest
+
+from src import LayerAdvisor, SevenLayerObfuscator
+
+
+def round_trip(message: str) -> str:
+    advisor = LayerAdvisor(seed=1234)
+    plan = advisor.suggest_plan(message)
+    obfuscator = SevenLayerObfuscator(plan)
+    encrypted = obfuscator.obfuscate(message)
+    assert encrypted != message
+    return obfuscator.deobfuscate(encrypted)
+
+
+def test_round_trip_ascii():
+    message = "Hello, layered obfuscation!"
+    assert round_trip(message) == message
+
+
+def test_round_trip_unicode():
+    message = "Привет, мир — 😀"
+    assert round_trip(message) == message
+
+
+def test_different_messages_produce_different_payloads():
+    advisor = LayerAdvisor(seed=42)
+    plan_a = advisor.suggest_plan("first message")
+    plan_b = advisor.suggest_plan("second message")
+    obfuscator_a = SevenLayerObfuscator(plan_a)
+    obfuscator_b = SevenLayerObfuscator(plan_b)
+    assert obfuscator_a.obfuscate("first message") != obfuscator_b.obfuscate("second message")
+
+
+def test_invalid_deobfuscation_raises():
+    advisor = LayerAdvisor(seed=1)
+    plan = advisor.suggest_plan("validate")
+    obfuscator = SevenLayerObfuscator(plan)
+    payload = obfuscator.obfuscate("validate")
+    # Corrupt the payload by dropping the last character.
+    with pytest.raises(ValueError):
+        obfuscator.deobfuscate(payload[:-1])


### PR DESCRIPTION
## Summary
- add a heuristic LayerAdvisor that derives seven-layer obfuscation plans
- implement a reversible SevenLayerObfuscator pipeline and document how to use it
- cover the workflow with pytest-based roundtrip and corruption tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfe86ea7b08323896f50b631cfcdcd